### PR TITLE
Add jenkins client

### DIFF
--- a/cmd/controller/app/controllers.go
+++ b/cmd/controller/app/controllers.go
@@ -27,6 +27,7 @@ import (
 	"kubesphere.io/devops/controllers/s2ibinary"
 	"kubesphere.io/devops/controllers/s2irun"
 	"kubesphere.io/devops/pkg/client/devops"
+	"kubesphere.io/devops/pkg/client/devops/jclient"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/client/s3"
 	"kubesphere.io/devops/pkg/informers"
@@ -35,7 +36,7 @@ import (
 )
 
 func addControllers(mgr manager.Manager, client k8s.Client, informerFactory informers.InformerFactory,
-	devopsClient devops.Interface, s3Client s3.Interface, s *options.DevOpsControllerManagerOptions,
+	devopsClient devops.Interface, jenkinsClient jclient.JenkinsClient, s3Client s3.Interface, s *options.DevOpsControllerManagerOptions,
 	stopCh <-chan struct{}) error {
 
 	kubesphereInformer := informerFactory.KubeSphereSharedInformerFactory()
@@ -67,7 +68,7 @@ func addControllers(mgr manager.Manager, client k8s.Client, informerFactory info
 			informerFactory.KubeSphereSharedInformerFactory().Devops().V1alpha3().DevOpsProjects())
 
 		devopsPipelineController = pipeline.NewController(client.Kubernetes(),
-			client.KubeSphere(), devopsClient,
+			client.KubeSphere(), devopsClient, jenkinsClient,
 			informerFactory.KubernetesSharedInformerFactory().Core().V1().Namespaces(),
 			informerFactory.KubeSphereSharedInformerFactory().Devops().V1alpha3().Pipelines())
 

--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -21,6 +21,7 @@ import (
 	"kubesphere.io/devops/cmd/controller/app/options"
 	"kubesphere.io/devops/pkg/apis"
 	"kubesphere.io/devops/pkg/client/devops"
+	"kubesphere.io/devops/pkg/client/devops/jclient"
 	"kubesphere.io/devops/pkg/client/devops/jenkins"
 	"kubesphere.io/devops/pkg/client/k8s"
 	"kubesphere.io/devops/pkg/client/s3"
@@ -109,9 +110,14 @@ func Run(s *options.DevOpsControllerManagerOptions, stopCh <-chan struct{}) erro
 
 	// Init DevOps client while Jenkins options and Jenkins host
 	var devopsClient devops.Interface
+	var jenkinsClient jclient.JenkinsClient
 	if s.JenkinsOptions != nil && len(s.JenkinsOptions.Host) != 0 {
 		// Make sure that Jenkins host is not empty
 		devopsClient, err = jenkins.NewDevopsClient(s.JenkinsOptions)
+		if err != nil {
+			return fmt.Errorf("failed to connect jenkins, please check jenkins status, error: %v", err)
+		}
+		jenkinsClient, err = jclient.NewJenkinsClient(s.JenkinsOptions)
 		if err != nil {
 			return fmt.Errorf("failed to connect jenkins, please check jenkins status, error: %v", err)
 		}
@@ -169,6 +175,7 @@ func Run(s *options.DevOpsControllerManagerOptions, stopCh <-chan struct{}) erro
 		kubernetesClient,
 		informerFactory,
 		devopsClient,
+		jenkinsClient,
 		s3Client,
 		s,
 		stopCh); err != nil {

--- a/controllers/pipeline/pipeline_controller.go
+++ b/controllers/pipeline/pipeline_controller.go
@@ -73,11 +73,13 @@ type Controller struct {
 
 	workerLoopPeriod time.Duration
 	devopsClient     devopsClient.Interface
+	jenkinsClient    jclient.JenkinsClient
 }
 
 func NewController(client clientset.Interface,
 	kubesphereClient kubesphereclient.Interface,
 	devopsClient devopsClient.Interface,
+	jenkinsClient    jclient.JenkinsClient,
 	namespaceInformer corev1informer.NamespaceInformer,
 	devopsInformer devopsinformers.PipelineInformer) *Controller {
 	broadcaster := record.NewBroadcaster()
@@ -90,6 +92,7 @@ func NewController(client clientset.Interface,
 	v := &Controller{
 		client:              client,
 		devopsClient:        devopsClient,
+		jenkinsClient:       jenkinsClient,
 		kubesphereClient:    kubesphereClient,
 		workqueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "pipeline"),
 		devOpsProjectLister: devopsInformer.Lister(),
@@ -271,8 +274,7 @@ func (c *Controller) syncHandler(key string) error {
 			}
 		} else {
 			// _, err := c.devopsClient.CreateProjectPipeline(nsName, copyPipeline)
-			jcli := jclient.JenkinsClient{}
-			_, err = jcli.CreateProjectPipeline(nsName, copyPipeline)
+			_, err = c.jenkinsClient.CreateProjectPipeline(nsName, copyPipeline)
 			if err != nil {
 				klog.V(8).Info(err, fmt.Sprintf("failed to create copyPipeline %s ", key))
 				return err

--- a/pkg/client/devops/jclient/jenkins.go
+++ b/pkg/client/devops/jclient/jenkins.go
@@ -1,49 +1,36 @@
 package jclient
 
 import (
-	"io/ioutil"
-
 	client "github.com/jenkins-zh/jenkins-client/pkg/core"
-	"gopkg.in/yaml.v2"
+	"kubesphere.io/devops/pkg/client/devops/jenkins"
 )
 
 type JenkinsClient struct {
-	
-}
-type Config struct {
-	Jenkins JenkinsConfig `yaml:"devops,omitempty"`
-}
-type JenkinsConfig struct {
-	URL      string `yaml:"host"`
-	UserName string `yaml:"username"`
-	Password string `yaml:"password"`
-	Token    string `yaml:"token,omitempty"`
+	Core client.JenkinsCore
 }
 
-func GetJenkinsCore() (core client.JenkinsCore, e error) {
-	// read configuration files
-	jenkinsConfigPath := "/etc/kubesphere/kubesphere.yaml"
-	yamlFile, e := ioutil.ReadFile(jenkinsConfigPath)
-	if e != nil {
-		return
+func NewJenkinsOptions() *jenkins.Options {
+	return &jenkins.Options{
+		Host:     "",
+		Username: "",
+		Password: "",
 	}
-	// yaml parse
-	var config Config
-	e = yaml.Unmarshal(yamlFile, &config)
-	if e != nil {
-		return
-	}
-	// capsulate JenkinsCore
-	core = client.JenkinsCore{
-		URL:      config.Jenkins.URL,
-		UserName: config.Jenkins.UserName,
-		Token:    config.Jenkins.Password,
+}
+
+func NewJenkinsClient(options *jenkins.Options) (jenkinsClient JenkinsClient, err error) {
+	core := client.JenkinsCore{
+		URL:      options.Host,
+		UserName: options.Username,
+		Token:    options.Password,
 	}
 	crumbIssuer, e := core.GetCrumb()
 	if e != nil {
 		return
 	} else if crumbIssuer != nil {
 		core.JenkinsCrumb = *crumbIssuer
+	}
+	jenkinsClient = JenkinsClient{
+		Core: core,
 	}
 	return
 }

--- a/pkg/client/devops/jclient/projectPipeline.go
+++ b/pkg/client/devops/jclient/projectPipeline.go
@@ -13,13 +13,8 @@ import (
 )
 
 func (j *JenkinsClient) CreateProjectPipeline(projectID string, pipeline *v1alpha3.Pipeline) (string, error) {
-	core, err := GetJenkinsCore()
 	jclient := job.Client{
-		JenkinsCore: core,
-		Parent: "",
-	}
-	if err != nil {
-		return "", err
+		JenkinsCore: j.Core,
 	}
 	projectPipelineName := fmt.Sprintf("%s %s", projectID, pipeline.Spec.Pipeline.Name)
 	job, _ := jclient.GetJob(projectPipelineName)

--- a/pkg/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/client/devops/jenkins/pipeline_internal.go
@@ -122,7 +122,9 @@ func parsePipelineConfigXml(config string) (*devopsv1alpha3.NoScmPipeline, error
 	if flow == nil {
 		return nil, fmt.Errorf("can not find pipeline definition")
 	}
-	pipeline.Description = flow.SelectElement("description").Text()
+	if node := flow.SelectElement("description"); node != nil {
+		pipeline.Description = node.Text()
+	}
 
 	properties := flow.SelectElement("properties")
 	if properties.


### PR DESCRIPTION
What I did in this PR?
* Get rid of the previous incorrect way of loading Jenkins config.
* Add jenkins client to controller to load config just like the other clients.
* Modify the previous use of job client. 

Why I did this change?
* The previous loading method was read yaml file directly. However, there is a loading process where all the clients load config together. 
* Each time ks-devops creates a pipeline, it will get crumbIssuer. However, we could initiate a client only once when loading config. 

How did I do this?
According to how other clients load config and add controller and add jenkins client following the devops client. 

What else?
There should be only ONE devops client at the end. The jenkins client I have added should either replace the previous devops client or become a part of a new devops client. So, adding jenkins client is temporary. It is just an easy way to develop or refactor one part in the project and, at the same time, to keep the other parts running. 